### PR TITLE
chore: Structured Logs + Exit Code

### DIFF
--- a/cmd/users-relay/main.go
+++ b/cmd/users-relay/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"github.com/yael-castro/goarch/internal/container"
 	"github.com/yael-castro/goarch/internal/runtime"
-	"log"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -12,19 +12,35 @@ import (
 )
 
 func main() {
+	// Setting exit code
+	exitCode := 0
+	defer func() {
+		os.Exit(exitCode)
+	}()
+
 	// Building main context
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill, syscall.SIGTERM)
 	defer stop()
 
-	// Declaration of dependencies
-	var cmd func(context.Context, ...string) int
-
-	// Injecting dependencies
+	// Building main command
 	c := container.New()
 
-	err := c.Inject(ctx, &cmd)
-	if err != nil {
-		log.Println(err)
+	// Injecting logger
+	var logger *slog.Logger
+
+	if err := c.Inject(ctx, &logger); err != nil {
+		exitCode = 1
+		return
+	}
+
+	slog.SetDefault(logger) // Setting a default logger
+
+	// Injecting command
+	var cmd func(context.Context, ...string) int
+
+	if err := c.Inject(ctx, &cmd); err != nil {
+		exitCode = 1
+		slog.Error("failed_command_built", "error", err)
 		return
 	}
 
@@ -54,20 +70,16 @@ func main() {
 	go func() {
 		defer close(exitCodeCh)
 
-		log.Printf("Message relay version '%s' is running", runtime.GitCommit)
+		slog.InfoContext(ctx, "message_relay_running", "version", runtime.GitCommit)
 		exitCodeCh <- cmd(ctx)
 	}()
 
 	// Waiting for cancellation or exit code
 	select {
 	case <-ctx.Done():
-		stop()
-		<-shutdownCh
-
-	case exitCode := <-exitCodeCh:
-		stop()
-		<-shutdownCh
-
-		os.Exit(exitCode)
+	case exitCode = <-exitCodeCh:
+		slog.InfoContext(ctx, "message_relay_exited", "exit_code", exitCode)
 	}
+
+	<-shutdownCh
 }

--- a/internal/app/business/mock/ports.go
+++ b/internal/app/business/mock/ports.go
@@ -3,13 +3,11 @@ package mock
 import (
 	"context"
 	"github.com/yael-castro/goarch/internal/app/business"
-	"log"
 )
 
 type MessageSender struct{}
 
-func (MessageSender) SendMessage(ctx context.Context, message *business.Message) error {
-	log.Printf("MESSAGE: %+v", message)
+func (MessageSender) SendMessage(context.Context, *business.Message) error {
 	return nil
 }
 

--- a/internal/app/input/command/relay.go
+++ b/internal/app/input/command/relay.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"github.com/yael-castro/goarch/internal/app/business"
-	"log"
+	"log/slog"
 )
 
 const (
@@ -13,15 +13,15 @@ const (
 )
 
 // Relay builds the command for message relay
-func Relay(relay business.MessagesRelay, errLogger *log.Logger) (func(context.Context, ...string) int, error) {
-	if relay == nil || errLogger == nil {
+func Relay(relay business.MessagesRelay, logger *slog.Logger) (func(context.Context, ...string) int, error) {
+	if relay == nil || logger == nil {
 		return nil, errors.New("some dependencies are nil")
 	}
 
 	return func(ctx context.Context, _ ...string) int {
 		err := relay.RelayMessages(ctx)
 		if err != nil {
-			errLogger.Println(err)
+			logger.ErrorContext(ctx, err.Error())
 			return fatalExitCode
 		}
 

--- a/internal/app/input/command/relay.go
+++ b/internal/app/input/command/relay.go
@@ -21,7 +21,7 @@ func Relay(relay business.MessagesRelay, logger *slog.Logger) (func(context.Cont
 	return func(ctx context.Context, _ ...string) int {
 		err := relay.RelayMessages(ctx)
 		if err != nil {
-			logger.ErrorContext(ctx, err.Error())
+			logger.ErrorContext(ctx, "fatal_error_message_relay", "error", err)
 			return fatalExitCode
 		}
 

--- a/internal/app/output/postgres/messages.go
+++ b/internal/app/output/postgres/messages.go
@@ -6,19 +6,19 @@ import (
 	"context"
 	"database/sql"
 	"github.com/yael-castro/goarch/internal/app/business"
-	"log"
+	"log/slog"
 )
 
-func NewMessagesReader(db *sql.DB, info *log.Logger) business.MessagesReader {
+func NewMessagesReader(db *sql.DB, logger *slog.Logger) business.MessagesReader {
 	return messageReader{
-		db:   db,
-		info: info,
+		db:     db,
+		logger: logger,
 	}
 }
 
 type messageReader struct {
-	db   *sql.DB
-	info *log.Logger
+	db     *sql.DB
+	logger *slog.Logger
 }
 
 func (p messageReader) ReadMessages(ctx context.Context, messages []business.Message) (int, error) {


### PR DESCRIPTION
In this commit I have replaced common logs with structured logs to improve debugging using logs.

The purpose of this change is to debug structured logs using tools or services like [CloudWatch Logs Insights
](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html)
Other changes made:
In the process I have fixed the incorrect way in which the `exit code` was returned.