### PR TITLE
fix: Wrong way to shutdown gracefully

### DIFF
--- a/cmd/users-http/main.go
+++ b/cmd/users-http/main.go
@@ -71,23 +71,23 @@ func main() {
 	go func() {
 		defer close(errCh)
 
-		slog.InfoContext(ctx, "http_server_is_running", "version", runtime.GitCommit, "port", port)
+		slog.InfoContext(ctx, "running", "version", runtime.GitCommit, "port", port)
 		errCh <- e.Start(":" + port)
 	}()
 
 	// Waiting for cancellation or error
+	var err error
+
 	select {
 	case <-ctx.Done():
-		<-shutdownCh
-
-	case err := <-errCh:
-		stop()
-		<-shutdownCh
-
+	case err = <-errCh:
 		exitCode = 1
-
-		slog.Error("", err)
 	}
+
+	stop()
+	<-shutdownCh
+
+	slog.Error("exit", "code", exitCode, "error", err)
 }
 
 func shutdown(c container.Container, e *echo.Echo) {

--- a/cmd/users-relay/main.go
+++ b/cmd/users-relay/main.go
@@ -70,7 +70,7 @@ func main() {
 	go func() {
 		defer close(exitCodeCh)
 
-		slog.InfoContext(ctx, "message_relay_running", "version", runtime.GitCommit)
+		slog.InfoContext(ctx, "running", "version", runtime.GitCommit)
 		exitCodeCh <- cmd(ctx)
 	}()
 
@@ -78,8 +78,10 @@ func main() {
 	select {
 	case <-ctx.Done():
 	case exitCode = <-exitCodeCh:
-		slog.InfoContext(ctx, "message_relay_exited", "exit_code", exitCode)
 	}
 
+	stop()
 	<-shutdownCh
+
+	slog.InfoContext(ctx, "exit", "code", exitCode)
 }


### PR DESCRIPTION
This commit fixes the following bug: Shutdown does not work for the message relay and the server when an error occurs.